### PR TITLE
Update registry swagger specs

### DIFF
--- a/specifications/registry/openapi.yaml
+++ b/specifications/registry/openapi.yaml
@@ -588,6 +588,10 @@ components:
         subscriber_id:
           type: string
           example: sit.grab.in
+        unique_key_id:
+          description: A unique number for tracking NP's key pairs.
+          example: "nova-some-uuid"
+          type: string
         callback_url:
           type: string
           description: it should be relative to subscriber_id mentioned domain. In below example with subscriber _id as abc.com, regsitry will call https://abc.com/ondc/onboarding/on_subscribe


### PR DESCRIPTION
Entity schema did not specify `unique_key_id` as a required field, and it is expected by ONDC Registry.